### PR TITLE
Use flag aliases correctly

### DIFF
--- a/main.go
+++ b/main.go
@@ -28,7 +28,8 @@ func main() {
 			EnvVars: []string{"WSCAT_ORIGIN"},
 		},
 		&cli.StringSliceFlag{
-			Name:    "header, H",
+			Name:    "header",
+			Aliases: []string{"H"},
 			Usage:   "headers to pass to the remote",
 			Value:   &cli.StringSlice{},
 			EnvVars: []string{"WSCAT_HEADER"},


### PR DESCRIPTION
This was missed in the move from v1 to v2 of urfave/cli.